### PR TITLE
Fix thread-local variables to use Boost compatibility layer

### DIFF
--- a/src/mapnik_python.cpp
+++ b/src/mapnik_python.cpp
@@ -29,6 +29,7 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #include "python_to_value.hpp"
+#include <boost/thread/tss.hpp>
 #include <boost/python/args.hpp>        // for keywords, arg, etc
 #include <boost/python/converter/from_python.hpp>
 #include <boost/python/def.hpp>         // for def
@@ -190,7 +191,7 @@ using mapnik::python_unblock_auto_block;
 #ifdef MAPNIK_DEBUG
 bool python_thread::thread_support = true;
 #endif
-thread_local std::unique_ptr<PyThreadState> python_thread::state;
+boost::thread_specific_ptr<PyThreadState> python_thread::state;
 
 struct agg_renderer_visitor_1
 {

--- a/src/mapnik_threads.hpp
+++ b/src/mapnik_threads.hpp
@@ -22,7 +22,7 @@
 #ifndef MAPNIK_THREADS_HPP
 #define MAPNIK_THREADS_HPP
 
-#include <thread>
+#include <boost/thread/tss.hpp>
 #include <Python.h>
 
 namespace mapnik {
@@ -70,7 +70,7 @@ public:
     }
 
 private:
-    static thread_local std::unique_ptr<PyThreadState> state;
+    static boost::thread_specific_ptr<PyThreadState> state;
 #ifdef MAPNIK_DEBUG
     static bool thread_support;
 #endif


### PR DESCRIPTION
Fixes #22 (apparently by cleanly reverting 427fc78). Be careful!