### PR TITLE
fix build on linux

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,6 +38,7 @@ if env['RUNTIME_LINK'] == 'static' and env['PLATFORM'] == 'Linux':
     py_env.AppendUnique(LIBS='rt')
 
 # TODO - do solaris/fedora need direct linking too?
+python_link_flag = ''
 if env['PLATFORM'] == 'Darwin':
     python_link_flag = '-undefined dynamic_lookup'
 


### PR DESCRIPTION
Fixes `'python_link_flag' is not defined` on linux when making `make python` from Mapnik core.

```
NameError: name 'python_link_flag' is not defined:
  File "/home/talaj/dev/mapnik/SConstruct", line 1983:
    SConscript('./bindings/python/build.py')
  File "/home/talaj/dev/mapnik/scons/scons-local-2.3.4/SCons/Script/SConscript.py", line 614:
    return method(*args, **kw)
  File "/home/talaj/dev/mapnik/scons/scons-local-2.3.4/SCons/Script/SConscript.py", line 551:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/talaj/dev/mapnik/scons/scons-local-2.3.4/SCons/Script/SConscript.py", line 260:
    exec _file_ in call_stack[-1].globals
  File "/home/talaj/dev/mapnik/bindings/python/build.py", line 105:
    py_env.Append(LINKFLAGS=python_link_flag)
make[1]: *** [mapnik] Error 2
make[1]: Leaving directory `/home/talaj/dev/mapnik'
make: *** [python] Error 2
```