### PR TITLE
Add missing parentheses in call to 'print'.

### DIFF
--- a/mapnik/printing.py
+++ b/mapnik/printing.py
@@ -942,7 +942,7 @@ class PDFPrinter:
                                     try:
                                         sym.avoid_edges=False
                                     except:
-                                        print "**** Cant set avoid edges for rule", r.name
+                                        print("**** Cant set avoid edges for rule", r.name)
                                 if r.min_scale <= m.scale_denominator() and m.scale_denominator() < r.max_scale:
                                     lerule = r
                                     lerule.min_scale = 0


### PR DESCRIPTION
With Python 3 the missing parentheses are a SyntaxError.

This change along with the setup.py changes in #38 allow building the python bindings with Python 3.4 (#36)