### PR TITLE
Add support for encoding data as a raw image bitmap to UTF grids

### DIFF
--- a/src/mapnik_grid.cpp
+++ b/src/mapnik_grid.cpp
@@ -44,7 +44,7 @@
 using namespace boost::python;
 
 // help compiler see template definitions
-static dict (*encode)( mapnik::grid const&, std::string const& , bool, unsigned int) = mapnik::grid_encode;
+static object (*encode)( mapnik::grid const&, std::string const& , bool, unsigned int) = mapnik::grid_encode;
 
 bool painted(mapnik::grid const& grid)
 {
@@ -80,7 +80,7 @@ void export_grid()
         .def("clear",&mapnik::grid::clear)
         .def("encode",encode,
              ( boost::python::arg("encoding")="utf", boost::python::arg("features")=true,boost::python::arg("resolution")=4 ),
-             "Encode the grid as as optimized json\n"
+             "Encode the grid as optimized json or bitmap\n"
             )
         .add_property("key",
                       make_function(&mapnik::grid::get_key,return_value_policy<copy_const_reference>()),

--- a/src/mapnik_grid_view.cpp
+++ b/src/mapnik_grid_view.cpp
@@ -46,7 +46,7 @@
 using namespace boost::python;
 
 // help compiler see template definitions
-static dict (*encode)( mapnik::grid_view const&, std::string const& , bool, unsigned int) = mapnik::grid_encode;
+static object (*encode)( mapnik::grid_view const&, std::string const& , bool, unsigned int) = mapnik::grid_encode;
 
 void export_grid_view()
 {
@@ -57,7 +57,7 @@ void export_grid_view()
         .def("height",&mapnik::grid_view::height)
         .def("encode",encode,
              ( boost::python::arg("encoding")="utf",boost::python::arg("add_features")=true,boost::python::arg("resolution")=4 ),
-             "Encode the grid as as optimized json\n"
+             "Encode the grid as optimized json or bitmap\n"
             )
         ;
 }

--- a/src/python_grid_utils.cpp
+++ b/src/python_grid_utils.cpp
@@ -329,23 +329,36 @@ void grid_encode_utf(T const& grid_type,
 }
 
 template <typename T>
-boost::python::dict grid_encode( T const& grid, std::string const& format, bool add_features, unsigned int resolution)
+boost::python::object grid_encode( T const& grid, std::string const& format, bool add_features, unsigned int resolution)
 {
     if (format == "utf") {
         boost::python::dict json;
         grid_encode_utf<T>(grid,json,add_features,resolution);
         return json;
-    }
-    else
-    {
+    } else if (format == "raw") {
+        if (add_features) {
+            std::stringstream s;
+            s << "'raw' format does not support feature metadata";
+            throw mapnik::value_error(s.str());
+        }
+
+        if (resolution != 1) {
+            std::stringstream s;
+            s << "'raw' currently only supports resolution = 1";
+            throw mapnik::value_error(s.str());
+        }
+
+        const char * grid_data = reinterpret_cast<const char*>(grid.data().bytes());
+        return boost::python::str(grid_data, grid.data().size());
+    } else {
         std::stringstream s;
-        s << "'utf' is currently the only supported encoding format.";
+        s << "'utf' and 'raw' are currently the only supported encoding formats.";
         throw mapnik::value_error(s.str());
     }
 }
 
-template boost::python::dict grid_encode( mapnik::grid const& grid, std::string const& format, bool add_features, unsigned int resolution);
-template boost::python::dict grid_encode( mapnik::grid_view const& grid, std::string const& format, bool add_features, unsigned int resolution);
+template boost::python::object grid_encode( mapnik::grid const& grid, std::string const& format, bool add_features, unsigned int resolution);
+template boost::python::object grid_encode( mapnik::grid_view const& grid, std::string const& format, bool add_features, unsigned int resolution);
 
 void render_layer_for_grid(mapnik::Map const& map,
                                   mapnik::grid & grid,

--- a/src/python_grid_utils.hpp
+++ b/src/python_grid_utils.hpp
@@ -64,7 +64,7 @@ void grid_encode_utf(T const& grid_type,
                             unsigned int resolution);
 
 template <typename T>
-boost::python::dict grid_encode( T const& grid, std::string const& format, bool add_features, unsigned int resolution);
+boost::python::object grid_encode( T const& grid, std::string const& format, bool add_features, unsigned int resolution);
 
 void render_layer_for_grid(const mapnik::Map& map,
                            mapnik::grid& grid,


### PR DESCRIPTION
This adds support for getting the raw image data rendered by the
mapnik grid renderer. The data is returned as 64-bit signed integers or
32-bit signed integers (host endian), depending on whether BIGINT
is true or not.