### PR TITLE
Add makefile for short test command lines (cf #45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ mapnik/paths.py
 .mason/
 mason_packages/
 mapnik/plugins
+.noseids

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: help test test_verbose tdd test_failed
+
+TEST := nosetests --logging-clear-handlers --with-id
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  test              to run all the test suite"
+	@echo "  test_verbose      to run all the test suite without output capture"
+	@echo "  tdd               to run all the test suite, but stop on the first error"
+	@echo "  test_failed       to rerun the failed tests from the previous run"
+
+test:
+	$(TEST) $(filter-out $@,$(MAKECMDGOALS))
+
+test_verbose:
+	$(TEST) -s $(filter-out $@,$(MAKECMDGOALS))
+
+tdd:
+	$(TEST) --stop --pdb $(filter-out $@,$(MAKECMDGOALS))
+
+test_failed:
+	python setup.py nosetests --logging-clear-handlers --with-id -vv --failed $(ARGS)
+
+%:
+	@:

--- a/test/python_tests/image_encoding_speed_test.py
+++ b/test/python_tests/image_encoding_speed_test.py
@@ -5,8 +5,7 @@ import os
 from timeit import Timer, time
 
 import mapnik
-
-from .utilities import execution_path, run_all
+from .utilities import execution_path
 
 
 def setup():
@@ -60,7 +59,7 @@ tiles = [
 iterations = 10
 
 
-def do_encoding():
+def test_encoding():
 
     global image
 
@@ -85,7 +84,7 @@ def do_encoding():
         blank_im = mapnik.Image(512, 512)
         for c in combinations:
             t = Timer(blank)
-            run(blank, blank_im, c, t)
+            yield run, blank, blank_im, c, t
 
     if 'solid' in tiles:
         def solid():
@@ -94,7 +93,7 @@ def do_encoding():
         solid_im.fill(mapnik.Color("#f2efe9"))
         for c in combinations:
             t = Timer(solid)
-            run(solid, solid_im, c, t)
+            yield run, solid, solid_im, c, t
 
     if 'many_colors' in tiles:
         def many_colors():
@@ -103,7 +102,7 @@ def do_encoding():
         many_colors_im = mapnik.Image.open('../data/images/13_4194_2747.png')
         for c in combinations:
             t = Timer(many_colors)
-            run(many_colors, many_colors_im, c, t)
+            yield run, many_colors, many_colors_im, c, t
 
     if 'aerial_24' in tiles:
         def aerial_24():
@@ -111,7 +110,7 @@ def do_encoding():
         aerial_24_im = mapnik.Image.open('../data/images/12_654_1580.png')
         for c in combinations:
             t = Timer(aerial_24)
-            run(aerial_24, aerial_24_im, c, t)
+            yield run, aerial_24, aerial_24_im, c, t
 
     for key, value in sorted(sortable.items(), key=lambda i: (i[1], i[0])):
         s = results[key]
@@ -123,9 +122,3 @@ def do_encoding():
         print(
             'min: %sms | avg: %sms | total: %sms | len: %s <-- %s' %
             (min_, avg, elapsed, size, name))
-
-
-if __name__ == "__main__":
-    setup()
-    do_encoding()
-    exit(run_all(eval(x) for x in dir() if x.startswith("test_")))


### PR DESCRIPTION
*Also make test/python_tests/image_encoding_speed_test.py compliant
with nosetest runner.*

This would allow to run tests like:

- `make test`: (default command, run all tests)
- `make test test/python_tests/image_encoding_speed_test.py`: run test of given file or directory only
- `make test_verbose [test/python_tests/image_encoding_speed_test.py]` run test without string capture (useful when we have custom prints), and just like `make test` can take a file or directory as argument
` make tdd`: run tests and stop at first failing test, running a pdb debugger for investigation, can take a file or directory as parameter
- `make test_failed`: rerun failed tests from last run
- `make help`: in case one have a memory black out ;)

All this can be done simply par running `nosetests` with the correct arguments, but the idea of the Makefile is to have the common needs so we don't have to remember the nose command line arguments.

This has been tested both on python 2.7 and python 3.4.