### PR TITLE
Add support for system fonts to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,11 +168,11 @@ elif create_paths:
 if create_paths:
     f_paths.write("inputpluginspath = os.path.join(mapniklibpath,'input')\n")
     if os.environ.get('SYSTEM_FONTS'):
-        font_path = "os.path.normpath('%s')" % os.environ.get('SYSTEM_FONTS')
+        font_path = "os.path.normpath('{path}')".format(path=os.environ.get('SYSTEM_FONTS'))
     else:
         font_path = "os.path.join(mapniklibpath,'fonts')"
     f_paths.write(
-        "fontscollectionpath = " + font_path + "\n")
+        "fontscollectionpath = {path}\n".format(path=font_path))
     f_paths.write(
         "__all__ = [mapniklibpath,inputpluginspath,fontscollectionpath]\n")
     f_paths.close()

--- a/setup.py
+++ b/setup.py
@@ -167,8 +167,12 @@ elif create_paths:
 
 if create_paths:
     f_paths.write("inputpluginspath = os.path.join(mapniklibpath,'input')\n")
+    if os.environ.get('SYSTEM_FONTS'):
+        font_path = "os.path.normpath('%s')" % os.environ.get('SYSTEM_FONTS')
+    else:
+        font_path = "os.path.join(mapniklibpath,'fonts')"
     f_paths.write(
-        "fontscollectionpath = os.path.join(mapniklibpath,'fonts')\n")
+        "fontscollectionpath = " + font_path + "\n")
     f_paths.write(
         "__all__ = [mapniklibpath,inputpluginspath,fontscollectionpath]\n")
     f_paths.close()


### PR DESCRIPTION
The same is supported in `build.py` if no `mapnik/paths.py` exists.

This issue was causing the python-mapnik Debian package to not use any fonts as reported in [Debian Bug #799473](https://bugs.debian.org/799473).

The mapnik Debian package is configured using `SYSTEM_FONTS=/usr/share/fonts`, python-mapnik should use the same path.

`build.py` has many options to customize the build, including support for the `SYSTEM_FONTS` environment variable, but `setup.py` already creates `mapnik/paths.py` causing `build.py` to not generate the custom one.

Maybe `setup.py` should also support fetching the paths using `mapnik-config --fonts` (and friends) instead of hardcoding the paths.