### PR TITLE
Support LIB_DIR_NAME environment variable for custom mapniklibpath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,11 @@ if mason_build:
         f_paths.write(
             'mapniklibpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "plugins")\n')
 elif create_paths:
-    f_paths.write("mapniklibpath = '" + lib_path + "/mapnik'\n")
+    if os.environ.get('LIB_DIR_NAME'):
+        mapnik_lib_path = lib_path + os.environ.get('LIB_DIR_NAME')
+    else:
+        mapnik_lib_path = lib_path + "/mapnik"
+    f_paths.write("mapniklibpath = '{path}'\n".format(path=mapnik_lib_path))
     f_paths.write('mapniklibpath = os.path.normpath(mapniklibpath)\n')
 
 if create_paths:


### PR DESCRIPTION
As reported in [Debian Bug #803564](https://bugs.debian.org/803564) and issue #62, the hardcoded `mapniklibpath` in `paths.py` is not correct when mapnik has been built using a custom `LIB_DIR_NAME`.

The mapnik Debian package is built using `LIB_DIR_NAME=/mapnik/3.0` for which this change adds support in `setup.py` for the python-mapnik build. It's quite similar to the `fontscollectionpath` change from #59.

Instead of, or in addition to, supporting custom paths using environment variables, may be `mapnik-config` should be used to retrieve the paths and fallback to the environment variables and hardcoded paths when unavailable.

`build.py` uses the `MAPNIK_LIB_DIR` environment variable to set the path for `mapniklibpath` in `paths.py`, that's also an option instead of specifying only part of the path with `LIB_DIR_NAME`.