### PR TITLE
Allow alternate error message for non-existent postgres user

### DIFF
--- a/test/python_tests/postgis_test.py
+++ b/test/python_tests/postgis_test.py
@@ -369,7 +369,8 @@ if 'postgis' in mapnik.DatasourceCache.plugin_names() \
                                 geometry_field='geom',
                                 user="rolethatdoesnotexist")
         except Exception as e:
-            assert 'role "rolethatdoesnotexist" does not exist' in str(e)
+            assert 'role "rolethatdoesnotexist" does not exist' in str(e) or \
+                'authentication failed for user "rolethatdoesnotexist"' in str(e)
 
     def test_empty_db():
         ds = mapnik.PostGIS(dbname=MAPNIK_TEST_DBNAME, table='empty')


### PR DESCRIPTION
I don't seem to get "role X does not exist" on my machine, rather I get:

```
Peer authentication failed for user "rolethatdoesnotexist"
```