### PR TITLE
Add some explicit register_ptr_to_python calls

### DIFF
--- a/src/mapnik_datasource.cpp
+++ b/src/mapnik_datasource.cpp
@@ -202,6 +202,7 @@ void export_datasource()
              "These vary depending on the type of data source.")
         .def(self == self)
         ;
+    register_ptr_to_python<std::shared_ptr<datasource> >();
 
     def("CreateDatasource",&create_datasource);
 

--- a/src/mapnik_feature.cpp
+++ b/src/mapnik_feature.cpp
@@ -237,4 +237,5 @@ void export_feature()
         .def("from_geojson",from_geojson_impl)
         .staticmethod("from_geojson")
         ;
+    register_ptr_to_python<std::shared_ptr<mapnik::feature_impl> >();
 }

--- a/src/mapnik_featureset.cpp
+++ b/src/mapnik_featureset.cpp
@@ -93,4 +93,5 @@ void export_featureset()
                       "<mapnik.Feature object at 0x105e64140>\n"
             )
         ;
+    register_ptr_to_python<std::shared_ptr<mapnik::Featureset> >();
 }

--- a/src/mapnik_geometry.cpp
+++ b/src/mapnik_geometry.cpp
@@ -290,4 +290,5 @@ void export_geometry()
         //.def("to_svg",&to_svg)
         // TODO add other geometry_type methods
         ;
+    register_ptr_to_python<std::shared_ptr<geometry<double>> >();
 }

--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -470,5 +470,6 @@ void export_image()
         .staticmethod("from_cairo")
 #endif
         ;
+    register_ptr_to_python<std::shared_ptr<image_any> >();
 
 }


### PR DESCRIPTION
If mapnik and python-mapnik are built with boost 1.60 then various python-mapnik test fail with errors like there:

```
TypeError: No to_python (by-value) converter found for C++ type: std::shared_ptr<mapnik::image_any>
```

There are reports of similar issues at http://permalink.gmane.org/gmane.comp.python.c++/16601 and in the comments of https://github.com/boostorg/python/issues/29 and it seems that the issue is that the shared pointers are being implicitly registered when used in the class definitions, but it seems to be unclear if this was a deliberate change or not.

This patch adds enough `register_ptr_to_python` calls to get the tests passing, but it's possible that there are others that need to be added that aren't caught be the calls - there are definitely others without explicit registration but it's not clear if the tests just aren't catching them or if they aren't a problem.