### PR TITLE
Avoid redefining Pycairo_CAPI

### DIFF
--- a/src/mapnik_image.cpp
+++ b/src/mapnik_image.cpp
@@ -44,6 +44,7 @@
 #include <mapnik/cairo/cairo_context.hpp>
 #include <mapnik/cairo/cairo_image_util.hpp>
 #if PY_MAJOR_VERSION >= 3
+#define PYCAIRO_NO_IMPORT
 #include <py3cairo.h>
 #else
 #include <pycairo.h>


### PR DESCRIPTION
Recent versions of pycairo declare `Pycairo_CAPI` as extern rather than static in the header, so if you include `py3cairo.h` in more than one file then you need to tell it to only declare it in the additional files by defining `PYCAIRO_NO_IMPORT`.