### PR TITLE
Fix libboost_python detection for boost1.71.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,10 @@ def find_boost_library(_id):
         # Debian naming convention for versions installed in parallel
         suffixes.insert(0, "-py%d%d" % (sys.version_info.major,
                                         sys.version_info.minor))
+        suffixes.insert(1, "%d%d" % (sys.version_info.major,
+                                     sys.version_info.minor))
         # standard suffix for Python3
-        suffixes.insert(1, sys.version_info.major)
+        suffixes.insert(2, sys.version_info.major)
     for suf in suffixes:
         name = "%s%s" % (_id, suf)
         lib = find_library(name)


### PR DESCRIPTION
The libboost-python-dev package in Debian changed from containing:
```
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python.a
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python.so
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python27.a
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python27.so
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python3-py38.a
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python3-py38.so
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python3.a
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python3.so
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python38.a
libboost-python1.67-dev: /usr/lib/x86_64-linux-gnu/libboost_python38.so
```
To only containing:
```
libboost-python1.71-dev: /usr/lib/x86_64-linux-gnu/libboost_python38.a
libboost-python1.71-dev: /usr/lib/x86_64-linux-gnu/libboost_python38.so
```