### PR TITLE
Compiling on MacOS Catalina + Homebrew: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Homebrew includes the python version in the libboost_python38.dylib name, which 
 
 ```
 git clone https://github.com/mapnik/python-mapnik ; cd python-mapnik
-BOOST_PYTHON=“boost_python38” python3 setup.py install
+BOOST_PYTHON=boost_python38 python3 setup.py install
 ```
 
 ### Building against Mapnik 3.0.x


### PR DESCRIPTION
This updates README.md with detailed and well tested instructions for compiling `python-mapnik` on MacOS Catalina systems using the very common homebrew packages.

This is a surprisingly difficult task as of Sep 2020, with a few time consuming gotchas. Three of us have spent a couple days each getting this working, seemed worth documenting at the README level for others, without the detailed docs python-mapnik is not casually installable on OSX for most people who are not really determined.