### PR TITLE
Fix AttributeError in geospatial PDF header

### DIFF
--- a/mapnik/printing/__init__.py
+++ b/mapnik/printing/__init__.py
@@ -1249,7 +1249,7 @@ class PDFPrinter(object):
             file_writer = PdfFileWriter()
 
             # preserve OCProperties at document root if we have one
-            if file_reader.trailer['/Root'].has_key(NameObject('/OCProperties')):
+            if '/OCProperties' in file_reader.trailer['/Root']:
                 file_writer._root_object[NameObject('/OCProperties')] = file_reader.trailer[
                     '/Root'].getObject()[NameObject('/OCProperties')]
 


### PR DESCRIPTION
I think when `mapnik.printing` switched from PyPDF to PyPDF2 it caused
this error:

>E  AttributeError: 'DictionaryObject' object has no attribute 'has_key'

This change fixes the error. String keys work just fine for these
objects, you don't need to wrap them in NameObject()