### PR TITLE
[WIP] refactor/enumerations https://github.com/mapnik/mapnik/pull/4372

### DIFF
--- a/src/mapnik_datasource.cpp
+++ b/src/mapnik_datasource.cpp
@@ -38,11 +38,11 @@
 #include <mapnik/datasource.hpp>
 #include <mapnik/datasource_cache.hpp>
 #include <mapnik/feature_layer_desc.hpp>
-#include <mapnik/memory_datasource.hpp>
+//#include <mapnik/memory_datasource.hpp>
 
 
 using mapnik::datasource;
-using mapnik::memory_datasource;
+//using mapnik::memory_datasource;
 using mapnik::layer_descriptor;
 using mapnik::attribute_descriptor;
 using mapnik::parameters;
@@ -197,7 +197,7 @@ void export_datasource()
         ;
 
     def("CreateDatasource",&create_datasource);
-
+    /*
     class_<memory_datasource,
            bases<datasource>, std::shared_ptr<memory_datasource>,
            boost::noncopyable>("MemoryDatasourceBase", init<parameters>())
@@ -210,4 +210,5 @@ void export_datasource()
         ;
 
     implicitly_convertible<std::shared_ptr<memory_datasource>,std::shared_ptr<datasource> >();
+    */
 }

--- a/src/mapnik_datasource.cpp
+++ b/src/mapnik_datasource.cpp
@@ -38,11 +38,11 @@
 #include <mapnik/datasource.hpp>
 #include <mapnik/datasource_cache.hpp>
 #include <mapnik/feature_layer_desc.hpp>
-//#include <mapnik/memory_datasource.hpp>
+#include <mapnik/memory_datasource.hpp>
 
 
 using mapnik::datasource;
-//using mapnik::memory_datasource;
+using mapnik::memory_datasource;
 using mapnik::layer_descriptor;
 using mapnik::attribute_descriptor;
 using mapnik::parameters;
@@ -197,7 +197,7 @@ void export_datasource()
         ;
 
     def("CreateDatasource",&create_datasource);
-    /*
+
     class_<memory_datasource,
            bases<datasource>, std::shared_ptr<memory_datasource>,
            boost::noncopyable>("MemoryDatasourceBase", init<parameters>())
@@ -210,5 +210,4 @@ void export_datasource()
         ;
 
     implicitly_convertible<std::shared_ptr<memory_datasource>,std::shared_ptr<datasource> >();
-    */
 }

--- a/src/mapnik_enumeration.hpp
+++ b/src/mapnik_enumeration.hpp
@@ -68,7 +68,7 @@ private:
             using namespace boost::python::converter;
             return base_type::base::to_python(
                 registered<native_type>::converters.m_class_object
-                ,  static_cast<long>( v ));
+                ,  static_cast<long>(native_type(v)));
 
         }
     };
@@ -76,11 +76,9 @@ private:
     void init() {
         boost::python::implicitly_convertible<native_type, EnumWrapper>();
         boost::python::to_python_converter<EnumWrapper, converter >();
-
-        for (unsigned i = 0; i < EnumWrapper::MAX; ++i)
+        for (auto const& kv : EnumWrapper::lookupMap())
         {
-            // Register the strings already defined for this enum.
-            base_type::value( EnumWrapper::get_string( i ), native_type( i ) );
+            base_type::value(kv.second.c_str(), kv.first);
         }
     }
 

--- a/src/mapnik_gamma_method.cpp
+++ b/src/mapnik_gamma_method.cpp
@@ -36,11 +36,11 @@ void export_gamma_method()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::gamma_method_e>("gamma_method")
-        .value("POWER", mapnik::GAMMA_POWER)
-        .value("LINEAR",mapnik::GAMMA_LINEAR)
-        .value("NONE", mapnik::GAMMA_NONE)
-        .value("THRESHOLD", mapnik::GAMMA_THRESHOLD)
-        .value("MULTIPLY", mapnik::GAMMA_MULTIPLY)
+        .value("POWER", mapnik::gamma_method_enum::GAMMA_POWER)
+        .value("LINEAR",mapnik::gamma_method_enum::GAMMA_LINEAR)
+        .value("NONE", mapnik::gamma_method_enum::GAMMA_NONE)
+        .value("THRESHOLD", mapnik::gamma_method_enum::GAMMA_THRESHOLD)
+        .value("MULTIPLY", mapnik::gamma_method_enum::GAMMA_MULTIPLY)
         ;
 
 }

--- a/src/mapnik_raster_colorizer.cpp
+++ b/src/mapnik_raster_colorizer.cpp
@@ -40,10 +40,10 @@ using mapnik::colorizer_stop;
 using mapnik::colorizer_stops;
 using mapnik::colorizer_mode_enum;
 using mapnik::color;
-using mapnik::COLORIZER_INHERIT;
-using mapnik::COLORIZER_LINEAR;
-using mapnik::COLORIZER_DISCRETE;
-using mapnik::COLORIZER_EXACT;
+using mapnik::colorizer_mode_enum::COLORIZER_INHERIT;
+using mapnik::colorizer_mode_enum::COLORIZER_LINEAR;
+using mapnik::colorizer_mode_enum::COLORIZER_DISCRETE;
+using mapnik::colorizer_mode_enum::COLORIZER_EXACT;
 
 
 namespace {

--- a/src/mapnik_raster_colorizer.cpp
+++ b/src/mapnik_raster_colorizer.cpp
@@ -40,11 +40,6 @@ using mapnik::colorizer_stop;
 using mapnik::colorizer_stops;
 using mapnik::colorizer_mode_enum;
 using mapnik::color;
-using mapnik::colorizer_mode_enum::COLORIZER_INHERIT;
-using mapnik::colorizer_mode_enum::COLORIZER_LINEAR;
-using mapnik::colorizer_mode_enum::COLORIZER_DISCRETE;
-using mapnik::colorizer_mode_enum::COLORIZER_EXACT;
-
 
 namespace {
 void add_stop(raster_colorizer_ptr & rc, colorizer_stop & stop)
@@ -196,10 +191,10 @@ void export_raster_colorizer()
         ;
 
     enum_<colorizer_mode_enum>("ColorizerMode")
-        .value("COLORIZER_INHERIT", COLORIZER_INHERIT)
-        .value("COLORIZER_LINEAR", COLORIZER_LINEAR)
-        .value("COLORIZER_DISCRETE", COLORIZER_DISCRETE)
-        .value("COLORIZER_EXACT", COLORIZER_EXACT)
+        .value("COLORIZER_INHERIT", colorizer_mode_enum::COLORIZER_INHERIT)
+        .value("COLORIZER_LINEAR", colorizer_mode_enum::COLORIZER_LINEAR)
+        .value("COLORIZER_DISCRETE", colorizer_mode_enum::COLORIZER_DISCRETE)
+        .value("COLORIZER_EXACT", colorizer_mode_enum::COLORIZER_EXACT)
         .export_values()
         ;
 

--- a/src/mapnik_style.cpp
+++ b/src/mapnik_style.cpp
@@ -69,8 +69,8 @@ void export_style()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::filter_mode_e>("filter_mode")
-        .value("ALL",mapnik::FILTER_ALL)
-        .value("FIRST",mapnik::FILTER_FIRST)
+        .value("ALL",mapnik::filter_mode_enum::FILTER_ALL)
+        .value("FIRST",mapnik::filter_mode_enum::FILTER_FIRST)
         ;
 
     class_<rules>("Rules",init<>("default ctor"))

--- a/src/mapnik_symbolizer.cpp
+++ b/src/mapnik_symbolizer.cpp
@@ -277,38 +277,38 @@ void export_text_symbolizer()
 {
     using namespace boost::python;
     mapnik::enumeration_<mapnik::label_placement_e>("label_placement")
-        .value("LINE_PLACEMENT", mapnik::LINE_PLACEMENT)
-        .value("POINT_PLACEMENT", mapnik::POINT_PLACEMENT)
-        .value("VERTEX_PLACEMENT", mapnik::VERTEX_PLACEMENT)
-        .value("INTERIOR_PLACEMENT", mapnik::INTERIOR_PLACEMENT);
+        .value("LINE_PLACEMENT", mapnik::label_placement_enum::LINE_PLACEMENT)
+        .value("POINT_PLACEMENT", mapnik::label_placement_enum::POINT_PLACEMENT)
+        .value("VERTEX_PLACEMENT", mapnik::label_placement_enum::VERTEX_PLACEMENT)
+        .value("INTERIOR_PLACEMENT", mapnik::label_placement_enum::INTERIOR_PLACEMENT);
 
     mapnik::enumeration_<mapnik::vertical_alignment_e>("vertical_alignment")
-        .value("TOP", mapnik::V_TOP)
-        .value("MIDDLE", mapnik::V_MIDDLE)
-        .value("BOTTOM", mapnik::V_BOTTOM)
-        .value("AUTO", mapnik::V_AUTO);
+        .value("TOP", mapnik::vertical_alignment_enum::V_TOP)
+        .value("MIDDLE", mapnik::vertical_alignment_enum::V_MIDDLE)
+        .value("BOTTOM", mapnik::vertical_alignment_enum::V_BOTTOM)
+        .value("AUTO", mapnik::vertical_alignment_enum::V_AUTO);
 
     mapnik::enumeration_<mapnik::horizontal_alignment_e>("horizontal_alignment")
-        .value("LEFT", mapnik::H_LEFT)
-        .value("MIDDLE", mapnik::H_MIDDLE)
-        .value("RIGHT", mapnik::H_RIGHT)
-        .value("AUTO", mapnik::H_AUTO);
+        .value("LEFT", mapnik::horizontal_alignment_enum::H_LEFT)
+        .value("MIDDLE", mapnik::horizontal_alignment_enum::H_MIDDLE)
+        .value("RIGHT", mapnik::horizontal_alignment_enum::H_RIGHT)
+        .value("AUTO", mapnik::horizontal_alignment_enum::H_AUTO);
 
     mapnik::enumeration_<mapnik::justify_alignment_e>("justify_alignment")
-        .value("LEFT", mapnik::J_LEFT)
-        .value("MIDDLE", mapnik::J_MIDDLE)
-        .value("RIGHT", mapnik::J_RIGHT)
-        .value("AUTO", mapnik::J_AUTO);
+        .value("LEFT", mapnik::justify_alignment_enum::J_LEFT)
+        .value("MIDDLE", mapnik::justify_alignment_enum::J_MIDDLE)
+        .value("RIGHT", mapnik::justify_alignment_enum::J_RIGHT)
+        .value("AUTO", mapnik::justify_alignment_enum::J_AUTO);
 
     mapnik::enumeration_<mapnik::text_transform_e>("text_transform")
-        .value("NONE", mapnik::NONE)
-        .value("UPPERCASE", mapnik::UPPERCASE)
-        .value("LOWERCASE", mapnik::LOWERCASE)
-        .value("CAPITALIZE", mapnik::CAPITALIZE);
+        .value("NONE", mapnik::text_transform_enum::NONE)
+        .value("UPPERCASE", mapnik::text_transform_enum::UPPERCASE)
+        .value("LOWERCASE", mapnik::text_transform_enum::LOWERCASE)
+        .value("CAPITALIZE", mapnik::text_transform_enum::CAPITALIZE);
 
     mapnik::enumeration_<mapnik::halo_rasterizer_e>("halo_rasterizer")
-        .value("FULL", mapnik::HALO_RASTERIZER_FULL)
-        .value("FAST", mapnik::HALO_RASTERIZER_FAST);
+        .value("FULL", mapnik::halo_rasterizer_enum::HALO_RASTERIZER_FULL)
+        .value("FAST", mapnik::halo_rasterizer_enum::HALO_RASTERIZER_FAST);
 
     class_< text_symbolizer, bases<symbolizer_base> >("TextSymbolizer",
                                                       init<>("Default ctor"))
@@ -343,8 +343,8 @@ void export_polygon_pattern_symbolizer()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::pattern_alignment_e>("pattern_alignment")
-        .value("LOCAL",mapnik::LOCAL_ALIGNMENT)
-        .value("GLOBAL",mapnik::GLOBAL_ALIGNMENT)
+        .value("LOCAL",mapnik::pattern_alignment_enum::LOCAL_ALIGNMENT)
+        .value("GLOBAL",mapnik::pattern_alignment_enum::GLOBAL_ALIGNMENT)
         ;
 
     class_<polygon_pattern_symbolizer>("PolygonPatternSymbolizer",
@@ -367,8 +367,8 @@ void export_point_symbolizer()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::point_placement_e>("point_placement")
-        .value("CENTROID",mapnik::CENTROID_POINT_PLACEMENT)
-        .value("INTERIOR",mapnik::INTERIOR_POINT_PLACEMENT)
+        .value("CENTROID",mapnik::point_placement_enum::CENTROID_POINT_PLACEMENT)
+        .value("INTERIOR",mapnik::point_placement_enum::INTERIOR_POINT_PLACEMENT)
         ;
 
     class_<point_symbolizer, bases<symbolizer_base> >("PointSymbolizer",
@@ -382,15 +382,15 @@ void export_markers_symbolizer()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::marker_placement_e>("marker_placement")
-        .value("POINT_PLACEMENT",mapnik::MARKER_POINT_PLACEMENT)
-        .value("INTERIOR_PLACEMENT",mapnik::MARKER_INTERIOR_PLACEMENT)
-        .value("LINE_PLACEMENT",mapnik::MARKER_LINE_PLACEMENT)
+        .value("POINT_PLACEMENT",mapnik::marker_placement_enum::MARKER_POINT_PLACEMENT)
+        .value("INTERIOR_PLACEMENT",mapnik::marker_placement_enum::MARKER_INTERIOR_PLACEMENT)
+        .value("LINE_PLACEMENT",mapnik::marker_placement_enum::MARKER_LINE_PLACEMENT)
         ;
 
     mapnik::enumeration_<mapnik::marker_multi_policy_e>("marker_multi_policy")
-        .value("EACH",mapnik::MARKER_EACH_MULTI)
-        .value("WHOLE",mapnik::MARKER_WHOLE_MULTI)
-        .value("LARGEST",mapnik::MARKER_LARGEST_MULTI)
+        .value("EACH",mapnik::marker_multi_policy_enum::MARKER_EACH_MULTI)
+        .value("WHOLE",mapnik::marker_multi_policy_enum::MARKER_WHOLE_MULTI)
+        .value("LARGEST",mapnik::marker_multi_policy_enum::MARKER_LARGEST_MULTI)
         ;
 
     class_<markers_symbolizer, bases<symbolizer_base> >("MarkersSymbolizer",
@@ -405,25 +405,25 @@ void export_line_symbolizer()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::line_rasterizer_e>("line_rasterizer")
-        .value("FULL",mapnik::RASTERIZER_FULL)
-        .value("FAST",mapnik::RASTERIZER_FAST)
+        .value("FULL",mapnik::line_rasterizer_enum::RASTERIZER_FULL)
+        .value("FAST",mapnik::line_rasterizer_enum::RASTERIZER_FAST)
         ;
 
     mapnik::enumeration_<mapnik::line_cap_e>("stroke_linecap",
                              "The possible values for a line cap used when drawing\n"
                              "with a stroke.\n")
-        .value("BUTT_CAP",mapnik::BUTT_CAP)
-        .value("SQUARE_CAP",mapnik::SQUARE_CAP)
-        .value("ROUND_CAP",mapnik::ROUND_CAP)
+        .value("BUTT_CAP",mapnik::line_cap_enum::BUTT_CAP)
+        .value("SQUARE_CAP",mapnik::line_cap_enum::SQUARE_CAP)
+        .value("ROUND_CAP",mapnik::line_cap_enum::ROUND_CAP)
         ;
 
     mapnik::enumeration_<mapnik::line_join_e>("stroke_linejoin",
                                       "The possible values for the line joining mode\n"
                                       "when drawing with a stroke.\n")
-        .value("MITER_JOIN",mapnik::MITER_JOIN)
-        .value("MITER_REVERT_JOIN",mapnik::MITER_REVERT_JOIN)
-        .value("ROUND_JOIN",mapnik::ROUND_JOIN)
-        .value("BEVEL_JOIN",mapnik::BEVEL_JOIN)
+        .value("MITER_JOIN",mapnik::line_join_enum::MITER_JOIN)
+        .value("MITER_REVERT_JOIN",mapnik::line_join_enum::MITER_REVERT_JOIN)
+        .value("ROUND_JOIN",mapnik::line_join_enum::ROUND_JOIN)
+        .value("BEVEL_JOIN",mapnik::line_join_enum::BEVEL_JOIN)
         ;
 
 
@@ -448,8 +448,8 @@ void export_debug_symbolizer()
     using namespace boost::python;
 
     mapnik::enumeration_<mapnik::debug_symbolizer_mode_e>("debug_symbolizer_mode")
-        .value("COLLISION",mapnik::DEBUG_SYM_MODE_COLLISION)
-        .value("VERTEX",mapnik::DEBUG_SYM_MODE_VERTEX)
+        .value("COLLISION",mapnik::debug_symbolizer_mode_enum::DEBUG_SYM_MODE_COLLISION)
+        .value("VERTEX",mapnik::debug_symbolizer_mode_enum::DEBUG_SYM_MODE_VERTEX)
         ;
 
     class_<debug_symbolizer, bases<symbolizer_base> >("DebugSymbolizer",


### PR DESCRIPTION
@mathisloge - I'm stumbling on some issues upgrading python bindings to use `refactor/enumerations` 

* Including `memory_datasource.hpp` pulls `datasource_plugin.hpp` which is not installed 
 (./plugins/input/base/include/mapnik)
* `using mapnik::colorizer_mode_enum::COLORIZER_INHERIT` is c++20 

Could you take a look, cheers. 