### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,7 +1,7 @@
 import glob
 import os
+import sysconfig
 from subprocess import Popen, PIPE
-from distutils import sysconfig
 
 Import('env')
 
@@ -14,11 +14,15 @@ def call(cmd, silent=True):
 
 
 prefix = env['PREFIX']
-target_path = os.path.normpath(sysconfig.get_python_lib() + os.path.sep + env['MAPNIK_NAME'])
+if "deb_system" in sysconfig.get_scheme_names():
+    python_modules_dir = sysconfig.get_path("purelib", "deb_system")
+else:
+    python_modules_dir = sysconfig.get_path("purelib")
+target_path = os.path.normpath(python_modules_dir + os.path.sep + env['MAPNIK_NAME'])
 
 py_env = env.Clone()
 
-py_env.Append(CPPPATH = sysconfig.get_python_inc())
+py_env.Append(CPPPATH = sysconfig.get_path('include'))
 
 py_env.Append(CPPDEFINES = env['LIBMAPNIK_DEFINES'])
 


### PR DESCRIPTION
`build.py` & `setup.py` still use the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3/library/platform.html#module-platform), [shutil](https://docs.python.org/3/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) has no suggestions for `distutils.sysconfig`, but [`sysconfig`](https://docs.python.org/3/library/sysconfig.html) is a reasonable alternative.

The `_config_vars` dict does not exist in the stdlib sysconfig module, hence the removal of the buildflag modifications in `setup.py`.