### PR TITLE
Don't require dependencies to be installed when clean target is executed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,143 +114,146 @@ else:
     mason_build = False
 
 
+extra_comp_args = []
 linkflags = []
-lib_path = os.path.join(check_output([mapnik_config, '--prefix']),'lib')
-linkflags.extend(check_output([mapnik_config, '--libs']).split(' '))
-linkflags.extend(check_output([mapnik_config, '--ldflags']).split(' '))
-linkflags.extend(check_output([mapnik_config, '--dep-libs']).split(' '))
-linkflags.extend([
-'-lmapnik-wkt',
-'-lmapnik-json',
-] + ['-l%s' % i for i in get_boost_library_names()])
 
-# Dynamically make the mapnik/paths.py file
-f_paths = open('mapnik/paths.py', 'w')
-f_paths.write('import os\n')
-f_paths.write('\n')
+if 'clean' not in sys.argv:
+    lib_path = os.path.join(check_output([mapnik_config, '--prefix']),'lib')
+    linkflags.extend(check_output([mapnik_config, '--libs']).split(' '))
+    linkflags.extend(check_output([mapnik_config, '--ldflags']).split(' '))
+    linkflags.extend(check_output([mapnik_config, '--dep-libs']).split(' '))
+    linkflags.extend([
+    '-lmapnik-wkt',
+    '-lmapnik-json',
+    ] + ['-l%s' % i for i in get_boost_library_names()])
 
-input_plugin_path = check_output([mapnik_config, '--input-plugins'])
-font_path = check_output([mapnik_config, '--fonts'])
+    # Dynamically make the mapnik/paths.py file
+    f_paths = open('mapnik/paths.py', 'w')
+    f_paths.write('import os\n')
+    f_paths.write('\n')
 
-if mason_build:
-    try:
-        if sys.platform == 'darwin':
-            base_f = 'libmapnik.dylib'
-        else:
-            base_f = 'libmapnik.so'
-        f = os.path.join(lib_path, base_f)
-        if not os.path.exists(os.path.join('mapnik', 'lib')):
-            os.makedirs(os.path.join('mapnik', 'lib'))
-        shutil.copyfile(f, os.path.join('mapnik', 'lib', base_f))
-    except shutil.Error:
-        pass
-    input_plugin_files = os.listdir(input_plugin_path)
-    input_plugin_files = [os.path.join(
-        input_plugin_path, f) for f in input_plugin_files]
-    if not os.path.exists(os.path.join('mapnik', 'lib', 'mapnik', 'input')):
-        os.makedirs(os.path.join('mapnik', 'lib', 'mapnik', 'input'))
-    for f in input_plugin_files:
+    input_plugin_path = check_output([mapnik_config, '--input-plugins'])
+    font_path = check_output([mapnik_config, '--fonts'])
+
+    if mason_build:
         try:
-            shutil.copyfile(f, os.path.join(
-                'mapnik', 'lib', 'mapnik', 'input', os.path.basename(f)))
+            if sys.platform == 'darwin':
+                base_f = 'libmapnik.dylib'
+            else:
+                base_f = 'libmapnik.so'
+            f = os.path.join(lib_path, base_f)
+            if not os.path.exists(os.path.join('mapnik', 'lib')):
+                os.makedirs(os.path.join('mapnik', 'lib'))
+            shutil.copyfile(f, os.path.join('mapnik', 'lib', base_f))
         except shutil.Error:
             pass
-    font_files = os.listdir(font_path)
-    font_files = [os.path.join(font_path, f) for f in font_files]
-    if not os.path.exists(os.path.join('mapnik', 'lib', 'mapnik', 'fonts')):
-        os.makedirs(os.path.join('mapnik', 'lib', 'mapnik', 'fonts'))
-    for f in font_files:
-        try:
-            shutil.copyfile(f, os.path.join(
-                'mapnik', 'lib', 'mapnik', 'fonts', os.path.basename(f)))
-        except shutil.Error:
-            pass
-    f_paths.write(
-        'mapniklibpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib")\n')
-    f_paths.write("inputpluginspath = os.path.join(mapniklibpath, 'mapnik', 'input')\n")
-    f_paths.write("fontscollectionpath = os.path.join(mapniklibpath, 'mapnik', 'fonts')\n")
-    f_paths.write(
-        "__all__ = [mapniklibpath,inputpluginspath,fontscollectionpath]\n")
-    f_paths.close()
-else:
-    if os.environ.get('LIB_DIR_NAME'):
-        mapnik_lib_path = lib_path + os.environ.get('LIB_DIR_NAME')
+        input_plugin_files = os.listdir(input_plugin_path)
+        input_plugin_files = [os.path.join(
+            input_plugin_path, f) for f in input_plugin_files]
+        if not os.path.exists(os.path.join('mapnik', 'lib', 'mapnik', 'input')):
+            os.makedirs(os.path.join('mapnik', 'lib', 'mapnik', 'input'))
+        for f in input_plugin_files:
+            try:
+                shutil.copyfile(f, os.path.join(
+                    'mapnik', 'lib', 'mapnik', 'input', os.path.basename(f)))
+            except shutil.Error:
+                pass
+        font_files = os.listdir(font_path)
+        font_files = [os.path.join(font_path, f) for f in font_files]
+        if not os.path.exists(os.path.join('mapnik', 'lib', 'mapnik', 'fonts')):
+            os.makedirs(os.path.join('mapnik', 'lib', 'mapnik', 'fonts'))
+        for f in font_files:
+            try:
+                shutil.copyfile(f, os.path.join(
+                    'mapnik', 'lib', 'mapnik', 'fonts', os.path.basename(f)))
+            except shutil.Error:
+                pass
+        f_paths.write(
+            'mapniklibpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "lib")\n')
+        f_paths.write("inputpluginspath = os.path.join(mapniklibpath, 'mapnik', 'input')\n")
+        f_paths.write("fontscollectionpath = os.path.join(mapniklibpath, 'mapnik', 'fonts')\n")
+        f_paths.write(
+            "__all__ = [mapniklibpath,inputpluginspath,fontscollectionpath]\n")
+        f_paths.close()
     else:
-        mapnik_lib_path = lib_path + "/mapnik"
-    f_paths.write("mapniklibpath = '{path}'\n".format(path=mapnik_lib_path))
-    f_paths.write('mapniklibpath = os.path.normpath(mapniklibpath)\n')
-    f_paths.write(
-        "inputpluginspath = '{path}'\n".format(path=input_plugin_path))
-    f_paths.write(
-        "fontscollectionpath = '{path}'\n".format(path=font_path))
-    f_paths.write(
-        "__all__ = [mapniklibpath,inputpluginspath,fontscollectionpath]\n")
-    f_paths.close()
+        if os.environ.get('LIB_DIR_NAME'):
+            mapnik_lib_path = lib_path + os.environ.get('LIB_DIR_NAME')
+        else:
+            mapnik_lib_path = lib_path + "/mapnik"
+        f_paths.write("mapniklibpath = '{path}'\n".format(path=mapnik_lib_path))
+        f_paths.write('mapniklibpath = os.path.normpath(mapniklibpath)\n')
+        f_paths.write(
+            "inputpluginspath = '{path}'\n".format(path=input_plugin_path))
+        f_paths.write(
+            "fontscollectionpath = '{path}'\n".format(path=font_path))
+        f_paths.write(
+            "__all__ = [mapniklibpath,inputpluginspath,fontscollectionpath]\n")
+        f_paths.close()
 
 
-if mason_build:
+    if mason_build:
 
-    share_dir = 'share'
+        share_dir = 'share'
 
-    for dep in ['icu','gdal','proj']:
-        share_path = os.path.join('mapnik', share_dir, dep)
-        if not os.path.exists(share_path):
-            os.makedirs(share_path)
+        for dep in ['icu','gdal','proj']:
+            share_path = os.path.join('mapnik', share_dir, dep)
+            if not os.path.exists(share_path):
+                os.makedirs(share_path)
 
-    icu_path = 'mason_packages/.link/share/icu/*/*.dat'
-    icu_files = glob.glob(icu_path)
-    if len(icu_files) != 1:
-        raise Exception("Failed to find icu dat file at "+ icu_path)
-    for f in icu_files:
-        shutil.copyfile(f, os.path.join(
-            'mapnik', share_dir, 'icu', os.path.basename(f)))
-
-    gdal_path = 'mason_packages/.link/share/gdal/'
-    gdal_files = os.listdir(gdal_path)
-    gdal_files = [os.path.join(gdal_path, f) for f in gdal_files]
-    for f in gdal_files:
-        try:
+        icu_path = 'mason_packages/.link/share/icu/*/*.dat'
+        icu_files = glob.glob(icu_path)
+        if len(icu_files) != 1:
+            raise Exception("Failed to find icu dat file at "+ icu_path)
+        for f in icu_files:
             shutil.copyfile(f, os.path.join(
-                'mapnik', share_dir, 'gdal', os.path.basename(f)))
-        except shutil.Error:
-            pass
+                'mapnik', share_dir, 'icu', os.path.basename(f)))
 
-    proj_path = 'mason_packages/.link/share/proj/'
-    proj_files = os.listdir(proj_path)
-    proj_files = [os.path.join(proj_path, f) for f in proj_files]
-    for f in proj_files:
+        gdal_path = 'mason_packages/.link/share/gdal/'
+        gdal_files = os.listdir(gdal_path)
+        gdal_files = [os.path.join(gdal_path, f) for f in gdal_files]
+        for f in gdal_files:
+            try:
+                shutil.copyfile(f, os.path.join(
+                    'mapnik', share_dir, 'gdal', os.path.basename(f)))
+            except shutil.Error:
+                pass
+
+        proj_path = 'mason_packages/.link/share/proj/'
+        proj_files = os.listdir(proj_path)
+        proj_files = [os.path.join(proj_path, f) for f in proj_files]
+        for f in proj_files:
+            try:
+                shutil.copyfile(f, os.path.join(
+                    'mapnik', share_dir, 'proj', os.path.basename(f)))
+            except shutil.Error:
+                pass
+
+    extra_comp_args = check_output([mapnik_config, '--cflags']).split(' ')
+
+    extra_comp_args = list(filter(lambda arg: arg != "-fvisibility=hidden", extra_comp_args))
+
+    if os.environ.get("PYCAIRO", "false") == "true":
         try:
-            shutil.copyfile(f, os.path.join(
-                'mapnik', share_dir, 'proj', os.path.basename(f)))
-        except shutil.Error:
-            pass
+            extra_comp_args.append('-DHAVE_PYCAIRO')
+            dist = pkg_resources.get_distribution('pycairo')
+            print(dist.location)
+            print("-I%s/cairo/include".format(dist.location))
+            extra_comp_args.append("-I{0}/cairo/include".format(dist.location))
+            #extra_comp_args.extend(check_output(["pkg-config", '--cflags', 'pycairo']).strip().split(' '))
+            #linkflags.extend(check_output(["pkg-config", '--libs', 'pycairo']).strip().split(' '))
+        except:
+            raise Exception("Failed to find compiler options for pycairo")
 
-extra_comp_args = check_output([mapnik_config, '--cflags']).split(' ')
-
-extra_comp_args = list(filter(lambda arg: arg != "-fvisibility=hidden", extra_comp_args))
-
-if os.environ.get("PYCAIRO", "false") == "true":
-    try:
-        extra_comp_args.append('-DHAVE_PYCAIRO')
-        dist = pkg_resources.get_distribution('pycairo')
-        print(dist.location)
-        print("-I%s/cairo/include".format(dist.location))
-        extra_comp_args.append("-I{0}/cairo/include".format(dist.location))
-        #extra_comp_args.extend(check_output(["pkg-config", '--cflags', 'pycairo']).strip().split(' '))
-        #linkflags.extend(check_output(["pkg-config", '--libs', 'pycairo']).strip().split(' '))
-    except:
-        raise Exception("Failed to find compiler options for pycairo")
-
-if sys.platform == 'darwin':
-    extra_comp_args.append('-mmacosx-version-min=13.0')
-    # silence warning coming from boost python macros which
-    # would is hard to silence via pragma
-    extra_comp_args.append('-Wno-parentheses-equality')
-    linkflags.append('-mmacosx-version-min=13.0')
-else:
-    linkflags.append('-lrt')
-    linkflags.append('-Wl,-z,origin')
-    linkflags.append('-Wl,-rpath=$ORIGIN/lib')
+    if sys.platform == 'darwin':
+        extra_comp_args.append('-mmacosx-version-min=13.0')
+        # silence warning coming from boost python macros which
+        # would is hard to silence via pragma
+        extra_comp_args.append('-Wno-parentheses-equality')
+        linkflags.append('-mmacosx-version-min=13.0')
+    else:
+        linkflags.append('-lrt')
+        linkflags.append('-Wl,-z,origin')
+        linkflags.append('-Wl,-rpath=$ORIGIN/lib')
 
 if os.environ.get("CC", False) == False:
     os.environ["CC"] = check_output([mapnik_config, '--cxx'])


### PR DESCRIPTION
The Debian package build executes `python3 setup.py clean` outside the build chroot where the dependencies are not guaranteed to be installed.

The build related code should only be executed when `python3 setup.py <configure|build|test>` is run (inside the build chroot).